### PR TITLE
Cleanup + optional case bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Any and all contributions are welcome. Included is also a `cadius.pro` file you 
 
 ## Changelog
 
+#### 1.4.3
+- `os_GetFolderFiles` segfault fixed. Thanks [@beevik](https://github.com/beevik): [#26](https://github.com/mach-kernel/cadius/pull/26)!
+- `-C | --no-case-bits` option added to `ADDFILE`, `ADDFOLDER`, `REPLACEFILE`, `CREATEVOLUME`, and `CREATEFOLDER` actions: [#27](https://github.com/mach-kernel/cadius/pull/27).
+- Fix warnings.
+
 #### 1.4.2
 - `CREATEVOLUME` did not previously allow for the creation of 143kb images. Thanks [@inexorabletash](https://github.com/inexorabletash)!
 

--- a/Src/Dc_Memory.h
+++ b/Src/Dc_Memory.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #define MEMORY_INIT                 10
 #define MEMORY_FREE                 11
 
@@ -57,6 +59,7 @@ struct parameter
   char *folder_path;
 
   int verbose;
+  bool output_apple_single;
 };
 
 struct error

--- a/Src/Dc_Memory.h
+++ b/Src/Dc_Memory.h
@@ -60,6 +60,7 @@ struct parameter
 
   int verbose;
   bool output_apple_single;
+  bool zero_case_bits;
 };
 
 struct error

--- a/Src/Dc_Prodos.c
+++ b/Src/Dc_Prodos.c
@@ -23,7 +23,7 @@ static struct sub_directory_header *ODSReadSubDirectoryHeader(unsigned char *);
 static void GetAllDirectoryFile(struct prodos_image *);
 static void GetOneSubDirectoryFile(struct prodos_image *,char *,struct file_descriptive_entry *);
 static void BuildStorageTypeAscii(BYTE,char *,char *);
-static void BuildFileTypeAscii(BYTE,WORD,char *);
+static void BuildFileTypeAscii(BYTE,char *);
 static void BuildAccessAscii(BYTE,char *);
 static void BuildLowerCase(char *,WORD,char *);
 static int GetFileDataResourceSize(struct prodos_image *,struct file_descriptive_entry *);
@@ -413,7 +413,7 @@ struct file_descriptive_entry *ODSReadFileDescriptiveEntry(struct prodos_image *
 
   /* Valeurs Ascii */
   BuildStorageTypeAscii(file_entry->storage_type,file_entry->storage_type_ascii,file_entry->storage_type_ascii_short);
-  BuildFileTypeAscii(file_entry->file_type,file_entry->file_aux_type,file_entry->file_type_ascii);
+  BuildFileTypeAscii(file_entry->file_type,file_entry->file_type_ascii);
   BuildAccessAscii(file_entry->access,file_entry->access_ascii);
 
   /* Nom LowerCase */
@@ -854,7 +854,7 @@ static void BuildStorageTypeAscii(BYTE storage_type, char *ascii_rtn, char *asci
 /**************************************************************************/
 /*  BuildFileTypeAscii() :  Construction de la valeur Ascii du File Type. */
 /**************************************************************************/
-static void BuildFileTypeAscii(BYTE file_type, WORD file_auxtype, char *ascii_rtn)
+static void BuildFileTypeAscii(BYTE file_type, char *ascii_rtn)
 {
   if(file_type == 0x00)
     strcpy(ascii_rtn,"UNK");
@@ -1080,6 +1080,10 @@ static int GetFileDataResourceSize(struct prodos_image *current_image, struct fi
                   return(1);
                 }
             }
+          else 
+            {
+              nb_block = 0;
+            }
 
           /* On compte tous les blocs à 0 = Sparse */
           for(i=0; i<nb_block; i++)
@@ -1163,6 +1167,11 @@ static int GetFileDataResourceSize(struct prodos_image *current_image, struct fi
                     free(tab_index_block);
                   return(1);
                 }
+            }
+          else 
+            {
+              nb_block = 0;
+              index_block = 0;
             }
           file_entry->index_block += index_block;
 

--- a/Src/Dc_Shared.c
+++ b/Src/Dc_Shared.c
@@ -91,7 +91,7 @@ unsigned char *LoadTextFile(char *file_path, int *data_length_rtn)
   fseek(fd,0L,SEEK_SET);
    
   /* Allocation mémoire */
-  data = (unsigned char *) calloc(1,file_size+10);
+  data = calloc(1,file_size+10);
   if(data == NULL)
     {
       fclose(fd);

--- a/Src/File_AppleSingle.c
+++ b/Src/File_AppleSingle.c
@@ -195,8 +195,8 @@ struct as_from_prodos ASFromProdosFile(struct prodos_file *file)
   prodos_info->auxtype = as_field32(file->entry->file_aux_type);
 
   uint32_t payload_size = prodos_entry_offset + sizeof(as_prodos_info);
-  char *payload = malloc(payload_size);
-  char *seek = payload;
+  unsigned char *payload = malloc(payload_size);
+  unsigned char *seek = payload;
 
   memcpy(seek, as_header, sizeof(as_file_header));
   seek += sizeof(as_file_header);

--- a/Src/File_AppleSingle.c
+++ b/Src/File_AppleSingle.c
@@ -1,7 +1,8 @@
 #include "File_AppleSingle.h"
 #include "log.h"
+#include "os/os.h"
 
-const unsigned int AS_MAGIC = (uint32_t) 0x00051600;
+const unsigned static int AS_MAGIC = (uint32_t) 0x00051600;
 
 static uint32_t as_field32(uint32_t num)
 {
@@ -51,7 +52,7 @@ struct as_file_header *ASParseHeader(unsigned char *buf)
  * @param entry_buf  The entry buffer
  * @return
  */
-struct as_prodos_info *ASParseProdosEntry(unsigned char *entry_buf, DWORD length)
+struct as_prodos_info *ASParseProdosEntry(unsigned char *entry_buf)
 {
   struct as_prodos_info *prodos_entry = malloc(sizeof(as_prodos_info));
   struct as_prodos_info *buf_prodos_entry = (as_prodos_info *) entry_buf;
@@ -81,7 +82,7 @@ struct as_file_entry *ASGetEntries(struct as_file_header *header, unsigned char 
     header->num_entries * sizeof(as_file_entry)
   );
 
-  struct as_file_entry *buf_entries = buf + sizeof(as_file_header);
+  struct as_file_entry *buf_entries = (as_file_entry *) buf + sizeof(as_file_header);
   memcpy(entries, buf_entries, header->num_entries * sizeof(as_file_entry));
 
   if (IS_LITTLE_ENDIAN)
@@ -127,7 +128,7 @@ void ASDecorateProdosFileInfo(struct prodos_file *current_file, unsigned char *d
   if (prodos_entry->entry_id != prodos_file_info) return;
 
   struct as_prodos_info *info_meta = ASParseProdosEntry(
-    data + prodos_entry->offset, prodos_entry->length
+    data + prodos_entry->offset
   );
 
   if (!info_meta) return;

--- a/Src/File_AppleSingle.c
+++ b/Src/File_AppleSingle.c
@@ -82,7 +82,7 @@ struct as_file_entry *ASGetEntries(struct as_file_header *header, unsigned char 
     header->num_entries * sizeof(as_file_entry)
   );
 
-  struct as_file_entry *buf_entries = (as_file_entry *) buf + sizeof(as_file_header);
+  struct as_file_entry *buf_entries = (as_file_entry *) (buf + sizeof(as_file_header));
   memcpy(entries, buf_entries, header->num_entries * sizeof(as_file_entry));
 
   if (IS_LITTLE_ENDIAN)

--- a/Src/File_AppleSingle.h
+++ b/Src/File_AppleSingle.h
@@ -65,7 +65,7 @@ typedef struct as_prodos_info
 typedef struct as_from_prodos
 {
   uint16_t length;
-  char *data;
+  unsigned char *data;
 } as_from_prodos;
 
 #pragma pack(pop)

--- a/Src/File_AppleSingle.h
+++ b/Src/File_AppleSingle.h
@@ -17,7 +17,7 @@
 #include "Dc_Shared.h"
 #include "Dc_Prodos.h"
 
-const unsigned int AS_MAGIC;
+const unsigned static int AS_MAGIC;
 #define IS_LITTLE_ENDIAN 'APPL' == (uint32_t) 0x4150504C
 
 #pragma pack(push, 1)
@@ -73,7 +73,7 @@ typedef struct as_from_prodos
 bool ASIsAppleSingle(unsigned char *buf);
 
 struct as_file_header *ASParseHeader(unsigned char *buf);
-struct as_prodos_info *ASParseProdosEntry(unsigned char *entry_buf, DWORD length);
+struct as_prodos_info *ASParseProdosEntry(unsigned char *entry_buf);
 struct as_file_entry *ASGetEntries(struct as_file_header *header, unsigned char *buf);
 
 void ASDecorateDataFork(struct prodos_file *current_file, unsigned char *data, as_file_entry *data_fork_entry);

--- a/Src/Main.c
+++ b/Src/Main.c
@@ -370,7 +370,13 @@ int main(int argc, char *argv[])
       logf_info("  - Add file '%s' :\n",param->file_path);
 
       /** Ajoute le fichier dans l'archive **/
-      AddFile(current_image,param->file_path,param->prodos_folder_path,1);
+      AddFile(
+        current_image,
+        param->file_path,
+        param->prodos_folder_path,
+        param->zero_case_bits,
+        1
+      );
 
       /* Libération mémoire */
       mem_free_image(current_image);
@@ -386,7 +392,7 @@ int main(int argc, char *argv[])
       logf_info("  - Add folder '%s' :\n",param->folder_path);
 
       /** Ajoute l'ensemble des fichiers du répertoire dans l'archive **/
-      AddFolder(current_image,param->folder_path,param->prodos_folder_path);
+      AddFolder(current_image,param->folder_path,param->prodos_folder_path,param->zero_case_bits);
 
       /* Stat */
       logf("    => File(s) : %d,  Folder(s) : %d,  Error(s) : %d\n",current_image->nb_add_file,current_image->nb_add_folder,current_image->nb_add_error);
@@ -428,7 +434,13 @@ int main(int argc, char *argv[])
       DeleteProdosFile(current_image, prodos_file_name);
       log_on();
 
-      AddFile(current_image, param->file_path, param->prodos_folder_path,1);
+      AddFile(
+        current_image,
+        param->file_path,
+        param->prodos_folder_path,
+        param->zero_case_bits,
+        1
+      );
 
       free(prodos_file_name);
       mem_free_image(current_image);
@@ -563,14 +575,17 @@ void usage(char *program_path)
   logf("        %s DELETEVOLUME  <[2mg|hdv|po]_image_path>\n",program_path);
   logf("        ----\n");
   logf("        %s ADDFILE       <[2mg|hdv|po]_image_path>   <prodos_folder_path>  <file_path>\n",program_path);
+  logf("        [-C write zeros for name case word]\n");
   logf("        Specify a file's type and auxtype by formatting the file name: THING.S16#B30000\n");
   logf("        Delimiter must be '#'. Also works with REPLACEFILE, DELETEFILE, etc.\n");
   logf("        ----\n");
   logf("        %s REPLACEFILE   <[2mg|hdv|po]_image_path>   <prodos_folder_path>  <file_path>\n",program_path);
+  logf("        [-C write zeros for name case word]\n");
   logf("        You may also specify a different type/auxtype for the file you intend to replace\n");
   logf("        (i.e. by changing the suffix) \n");
   logf("        ----\n");
   logf("        %s ADDFOLDER     <[2mg|hdv|po]_image_path>   <prodos_folder_path>  <folder_path>\n",program_path);
+  logf("        [-C write zeros for name case word]\n");
   logf("        ----\n");
   logf("        %s CREATEFOLDER  <[2mg|hdv|po]_image_path>   <prodos_folder_path>\n",program_path);
   logf("        %s CREATEVOLUME  <[2mg|hdv|po]_image_path>   <volume_name>         <volume_size>\n",program_path);
@@ -985,7 +1000,7 @@ struct parameter *GetParamLine(int argc, char *argv[])
     }
 
   /** ADDFILE <2mg_image_path> <target_folder_path> <file_path> **/
-  if(!my_stricmp(argv[1],"ADDFILE") && argc == 5)
+  if(!my_stricmp(argv[1],"ADDFILE") && argc >= 5)
     {
       param->action = ACTION_ADD_FILE;
 
@@ -997,6 +1012,11 @@ struct parameter *GetParamLine(int argc, char *argv[])
 
       /* Chemin du fichier Windows */
       param->file_path = strdup(argv[4]);
+
+      // Write zeros for case bits
+      if (!my_stricmp(argv[5], "-C")) {
+        param -> zero_case_bits = true;
+      }
 
       /* Vérification */
       if(param->image_file_path == NULL || param->file_path == NULL || param->prodos_folder_path == NULL)
@@ -1037,7 +1057,7 @@ struct parameter *GetParamLine(int argc, char *argv[])
     }
 
   /** ADDFOLDER <2mg_image_path> <target_folder_path> <folder_path> **/
-  if(!my_stricmp(argv[1],"ADDFOLDER") && argc == 5)
+  if(!my_stricmp(argv[1],"ADDFOLDER") && argc >= 5)
     {
       param->action = ACTION_ADD_FOLDER;
 
@@ -1049,6 +1069,11 @@ struct parameter *GetParamLine(int argc, char *argv[])
 
       /* Chemin du fichier Windows */
       param->folder_path = strdup(argv[4]);
+
+      // Write zeros for case bits
+      if (!my_stricmp(argv[5], "-C")) {
+        param->zero_case_bits = true;
+      }
 
       /* Vérification */
       if(param->image_file_path == NULL || param->prodos_folder_path == NULL || param->folder_path == NULL)

--- a/Src/Main.c
+++ b/Src/Main.c
@@ -548,6 +548,20 @@ int apply_global_flags(struct parameter *params, int argc, char **argv)
   return argc-found;
 }
 
+void apply_command_flags(struct parameter *params, int start, int argc, char **argv)
+{
+  for (int i = start; i < argc; i++) {
+    if ((
+      params->action == ACTION_ADD_FILE ||
+      params->action == ACTION_REPLACE_FILE ||
+      params->action == ACTION_ADD_FOLDER)
+      && !my_stricmp(argv[i], "-C")
+    ) {
+      params->zero_case_bits = true;
+    }
+  }
+}
+
 /************************************************************/
 /*  usage() :  Indique les différentes options du logiciel. */
 /************************************************************/
@@ -1013,9 +1027,8 @@ struct parameter *GetParamLine(int argc, char *argv[])
       /* Chemin du fichier Windows */
       param->file_path = strdup(argv[4]);
 
-      // Write zeros for case bits
-      if (!my_stricmp(argv[5], "-C")) {
-        param -> zero_case_bits = true;
+      if (argc > 4) {
+        apply_command_flags(param, 5, argc, argv);
       }
 
       /* Vérification */
@@ -1031,7 +1044,7 @@ struct parameter *GetParamLine(int argc, char *argv[])
     }
 
   /** REPLACEFILE <2mg_image_path> <target_folder_path> <file_path> **/
-  if(!my_stricmp(argv[1],"REPLACEFILE") && argc == 5)
+  if(!my_stricmp(argv[1],"REPLACEFILE") && argc >= 5)
     {
       param->action = ACTION_REPLACE_FILE;
 
@@ -1043,6 +1056,10 @@ struct parameter *GetParamLine(int argc, char *argv[])
 
       /* Chemin du fichier Windows */
       param->file_path = strdup(argv[4]);
+
+      if (argc > 4) {
+        apply_command_flags(param, 5, argc, argv);
+      }
 
       /* Vérification */
       if(param->image_file_path == NULL || param->file_path == NULL || param->prodos_folder_path == NULL)
@@ -1070,9 +1087,8 @@ struct parameter *GetParamLine(int argc, char *argv[])
       /* Chemin du fichier Windows */
       param->folder_path = strdup(argv[4]);
 
-      // Write zeros for case bits
-      if (!my_stricmp(argv[5], "-C")) {
-        param->zero_case_bits = true;
+      if (argc > 4) {
+        apply_command_flags(param, 5, argc, argv);
       }
 
       /* Vérification */

--- a/Src/Prodos_Add.c
+++ b/Src/Prodos_Add.c
@@ -315,7 +315,7 @@ static struct prodos_file *LoadFile(char *file_path_data, bool zero_case_bits)
 
   // Start from end of string until we arrive to path delimiter
   strcpy(folder_path,file_path_data);
-  for(i=strlen(folder_path); i>=0; i--)
+  for(i=strlen(folder_path) - 1; i>=0; i--)
     if(!strncmp(&folder_path[i], FOLDER_CHARACTER, strlen(FOLDER_CHARACTER)))
       {
         folder_path[i+1] = '\0';
@@ -324,7 +324,7 @@ static struct prodos_file *LoadFile(char *file_path_data, bool zero_case_bits)
 
   // Similarly, also extract the filename
   strcpy(file_name,file_path_data);
-  for(i=strlen(file_path_data); i>=0; i--)
+  for(i=strlen(file_path_data) - 1; i>=0; i--)
     if(!strncmp(&folder_path[i], FOLDER_CHARACTER, strlen(FOLDER_CHARACTER)))
       {
         strcpy(file_name,&file_path_data[i+1]);

--- a/Src/Prodos_Add.c
+++ b/Src/Prodos_Add.c
@@ -704,6 +704,10 @@ static WORD CreateFileContent(struct prodos_image *current_image, struct prodos_
           if(file_block_number == 0)
             return(0);
         }
+      else
+        {
+          return(1);
+        }
     }
   else  /** Fichier Resource **/
     {
@@ -752,6 +756,10 @@ static WORD CreateFileContent(struct prodos_image *current_image, struct prodos_
           resource_block_number = CreateTreeContent(current_image,current_file,current_file->resource,current_file->resource_length,current_file->block_disk_resource,current_file->index_resource,0);
           if(resource_block_number == 0)
             return(0);
+        }
+      else
+        {
+          return(1); 
         }
 
       /** Remplissage de l'Extended block **/

--- a/Src/Prodos_Add.c
+++ b/Src/Prodos_Add.c
@@ -456,45 +456,45 @@ static int GetFileInformation(char *file_information_path, char *file_name, stru
           GetLineValue(line_tab[i],"Type",local_buffer);
           if(strlen(local_buffer) == 2)
             {
-              sscanf(local_buffer,"%02lX",&value);
+              sscanf(local_buffer,"%2X",&value);
               current_file->type = (unsigned char) value;
             }
           GetLineValue(line_tab[i],"AuxType",local_buffer);
           if(strlen(local_buffer) == 4)
             {
-              sscanf(local_buffer,"%04lX",&value);
+              sscanf(local_buffer,"%4X",&value);
               current_file->aux_type = (WORD) value;
             }
           GetLineValue(line_tab[i],"VersionCreate",local_buffer);
           if(strlen(local_buffer) == 2)
             {
-              sscanf(local_buffer,"%02lX",&value);
+              sscanf(local_buffer,"%2X",&value);
               current_file->version_create = (unsigned char) value;
             }
           GetLineValue(line_tab[i],"MinVersion",local_buffer);
           if(strlen(local_buffer) == 2)
             {
-              sscanf(local_buffer,"%02lX",&value);
+              sscanf(local_buffer,"%2X",&value);
               current_file->min_version = (unsigned char) value;
             }
           GetLineValue(line_tab[i],"Access",local_buffer);
           if(strlen(local_buffer) == 2)
             {
-              sscanf(local_buffer,"%02lX",&value);
+              sscanf(local_buffer,"%2X",&value);
               current_file->access = (unsigned char) value;
             }
           GetLineValue(line_tab[i],"FolderInfo1",local_buffer);
           if(strlen(local_buffer) == 36)
             for(j=0; j<18; j++)
               {
-                sscanf(&local_buffer[2*j],"%02lX",&value);
+                sscanf(&local_buffer[2*j],"%2X",&value);
                 current_file->resource_finderinfo_1[j] = (unsigned char) value;
               }
           GetLineValue(line_tab[i],"FolderInfo2",local_buffer);
           if(strlen(local_buffer) == 36)
             for(j=0; j<18; j++)
               {
-                sscanf(&local_buffer[2*j],"%02lX",&value);
+                sscanf(&local_buffer[2*j],"%2X",&value);
                 current_file->resource_finderinfo_2[j] = (unsigned char) value;
               }
             

--- a/Src/Prodos_Add.c
+++ b/Src/Prodos_Add.c
@@ -104,7 +104,7 @@ int AddFile(
     }
 
   /** Recherche/Construit le dossier Prodos Cible où placer le fichier **/
-  target_folder = BuildProdosFolderPath(current_image,target_folder_path,&is_volume_header,1);
+  target_folder = BuildProdosFolderPath(current_image,target_folder_path,&is_volume_header,zero_case_bits,1);
   if(target_folder == NULL && is_volume_header == 0)
     {
       mem_free_file(current_file);
@@ -220,7 +220,7 @@ void AddFolder(struct prodos_image *current_image, char *folder_path, char *targ
   char prodos_folder_path[1024];
 
   /** Recherche/Construit le dossier Prodos Cible où placer les fichiers **/
-  target_folder = BuildProdosFolderPath(current_image,target_folder_path,&is_volume_header,1);
+  target_folder = BuildProdosFolderPath(current_image,target_folder_path,&is_volume_header,zero_case_bits,1);
   if(target_folder == NULL && is_volume_header == 0)
     {
       current_image->nb_add_error++;

--- a/Src/Prodos_Add.h
+++ b/Src/Prodos_Add.h
@@ -6,7 +6,7 @@
 /*  Auteur : Olivier ZARDINI  *  Brutal Deluxe Software  *  Dec 2011  */
 /**********************************************************************/
 
-int AddFile(struct prodos_image *,char *,char *,int);
-void AddFolder(struct prodos_image *,char *,char *);
+int AddFile(struct prodos_image *,char *,char *,bool,int);
+void AddFolder(struct prodos_image *,char *,char *,bool);
 
 /***********************************************************************/

--- a/Src/Prodos_Create.c
+++ b/Src/Prodos_Create.c
@@ -59,13 +59,20 @@ unsigned char bitmap_mask[8] =
 /***********************************************************/
 /*  CreateProdosVolume() :  Création d'un nouveau Dossier. */
 /***********************************************************/
-void CreateProdosFolder(struct prodos_image *current_image, char *prodos_folder_path)
+void CreateProdosFolder(struct prodos_image *current_image, char *prodos_folder_path, bool zero_case_bits)
 {
   int error, is_volume_header;
   struct file_descriptive_entry *new_folder;
 
   /** Création du Dossier **/
-  new_folder = BuildProdosFolderPath(current_image,prodos_folder_path,&is_volume_header,0);
+  new_folder = BuildProdosFolderPath(
+    current_image,
+    prodos_folder_path,
+    &is_volume_header,
+    zero_case_bits,
+    0
+  );
+
   if(new_folder == NULL)
     return;
 
@@ -77,7 +84,12 @@ void CreateProdosFolder(struct prodos_image *current_image, char *prodos_folder_
 /********************************************************************/
 /*  CreateProdosVolume() :  Création d'une image Prodos 2mg/hdv/po. */
 /********************************************************************/
-struct prodos_image *CreateProdosVolume(char *image_file_path, char *volume_name, int volume_size_kb)
+struct prodos_image *CreateProdosVolume(
+  char *image_file_path,
+  char *volume_name,
+  int volume_size_kb,
+  bool zero_case_bits
+)
 {
   int i, error, is_valid, nb_image_block, nb_bitmap_block, image_format, image_header_size;
   DWORD nb_block, nb_byte;
@@ -130,7 +142,7 @@ struct prodos_image *CreateProdosVolume(char *image_file_path, char *volume_name
     upper_case[i] = toupper(upper_case[i]);
 
   /* 16 bit décrivant la case */
-  name_case = BuildProdosCase(volume_name);
+  name_case = zero_case_bits ? 0 : BuildProdosCase(volume_name);
 
   /* Date actuelle */
   GetCurrentDate(&now_date,&now_time);
@@ -262,7 +274,13 @@ struct prodos_image *CreateProdosVolume(char *image_file_path, char *volume_name
 /********************************************************************************************/
 /*  BuildProdosFolderPath() :  Création des dossiers nécessaires pour y ajouter le fichier. */
 /********************************************************************************************/
-struct file_descriptive_entry *BuildProdosFolderPath(struct prodos_image *current_image, char *target_folder_path_param, int *is_volume_header_rtn, int verbose)
+struct file_descriptive_entry *BuildProdosFolderPath(
+  struct prodos_image *current_image,
+  char *target_folder_path_param,
+  int *is_volume_header_rtn,
+  bool zero_case_bits,
+  int verbose
+)
 {
   int first_one, name_length;
   char *begin;
@@ -347,7 +365,7 @@ struct file_descriptive_entry *BuildProdosFolderPath(struct prodos_image *curren
         break;
 
       /* Création d'un répertoire vide dans le Dossier ou à la Racine du volume */
-      new_folder = CreateOneProdosFolder(current_image,current_folder,begin,verbose);
+      new_folder = CreateOneProdosFolder(current_image,current_folder,begin,zero_case_bits,verbose);
       if(new_folder == NULL)
         return(NULL);
 
@@ -367,7 +385,13 @@ struct file_descriptive_entry *BuildProdosFolderPath(struct prodos_image *curren
 /******************************************************************************************************/
 /*  CreateOneProdosFolder() :  Création d'un dossier vide dans un Directory ou à la Racine du volume. */
 /******************************************************************************************************/
-struct file_descriptive_entry *CreateOneProdosFolder(struct prodos_image *current_image, struct file_descriptive_entry *current_folder, char *folder_name, int verbose)
+struct file_descriptive_entry *CreateOneProdosFolder(
+  struct prodos_image *current_image,
+  struct file_descriptive_entry *current_folder,
+  char *folder_name,
+  bool zero_case_bits,
+  int verbose
+)
 {
   char upper_case[256];
   WORD name_case, now_date, now_time, file_count;
@@ -418,7 +442,7 @@ struct file_descriptive_entry *CreateOneProdosFolder(struct prodos_image *curren
     upper_case[i] = toupper(upper_case[i]);
 
   /* 16 bit décrivant la case */
-  name_case = BuildProdosCase(folder_name);
+  name_case = zero_case_bits ? 0 : BuildProdosCase(folder_name);
 
   /* Longueur du nom */
   name_length = (unsigned char) strlen(folder_name);

--- a/Src/Prodos_Create.h
+++ b/Src/Prodos_Create.h
@@ -6,9 +6,9 @@
 /*  Auteur : Olivier ZARDINI  *  Brutal Deluxe Software  *  Mar 2012  */
 /**********************************************************************/
 
-void CreateProdosFolder(struct prodos_image *,char *);
-struct prodos_image *CreateProdosVolume(char *,char *,int);
-struct file_descriptive_entry *CreateOneProdosFolder(struct prodos_image *,struct file_descriptive_entry *,char *,int);
-struct file_descriptive_entry *BuildProdosFolderPath(struct prodos_image *,char *,int *,int);
+void CreateProdosFolder(struct prodos_image *,char *,bool);
+struct prodos_image *CreateProdosVolume(char *,char *,int,bool);
+struct file_descriptive_entry *CreateOneProdosFolder(struct prodos_image *,struct file_descriptive_entry *,char *,bool,int);
+struct file_descriptive_entry *BuildProdosFolderPath(struct prodos_image *,char *,int *,bool,int);
 
 /***********************************************************************/

--- a/Src/Prodos_Dump.c
+++ b/Src/Prodos_Dump.c
@@ -52,7 +52,7 @@ void DumpProdosImage(struct prodos_image *current_image, int dump_structure)
   logf("Type   Aux      Size     Data     Res  Data   Res  Sparse Index  Struct  Access    Creation Date     Modification Date\n");
 
   /* Volume Name */
-  logf("/%s/\n",current_image->volume_header->volume_name);
+  logf("/%s/\n",current_image->volume_header->volume_name_case);
 
   /** Volume : Files **/
   for(i=0; i<current_image->nb_file; i++)
@@ -94,7 +94,7 @@ static void DumpOneDirectory(struct file_descriptive_entry *current_file, int ma
     logf("  ");
 
   /* Directory Name */
-  logf("/%s/\n",current_file->file_name);
+  logf("/%s/\n",current_file->file_name_case);
 
   /** All File **/
   for(i=0; i<current_file->nb_file; i++)

--- a/Src/Prodos_Extract.c
+++ b/Src/Prodos_Extract.c
@@ -292,7 +292,7 @@ static int CreateOutputFile(struct prodos_file *current_file, char *output_direc
     }
   strcpy(directory_path,output_directory_path);
 
-  if(strlen(directory_path) > 0 && directory_path[strlen(directory_path)-1] != FOLDER_CHARACTER)
+  if(strlen(directory_path) > 0 && strncmp(&directory_path[strlen(directory_path)-1], FOLDER_CHARACTER, 1))
     strcat(directory_path,FOLDER_CHARACTER);
 
   // Data file path
@@ -447,11 +447,11 @@ static void SetFileInformation(char *file_information_path, struct prodos_file *
 
       /* On ne recopie pas la ligne du fichier */
       if(my_stricmp(file_name,current_file->entry->file_name_case))
-         logf(fd,"%s\n",line_tab[i]);
+         logf("%s\n",line_tab[i]);
     }
 
   /* Nouvelle ligne */
-   logf(fd,"%s\n",local_buffer);
+   logf("%s\n",local_buffer);
 
   /* Fermeture */
   fclose(fd);

--- a/Src/Prodos_Move.c
+++ b/Src/Prodos_Move.c
@@ -48,7 +48,14 @@ void MoveProdosFile(struct prodos_image *current_image, char *prodos_file_path, 
     }
 
   /** Recherche le dossier Prodos Cible où déplacer le fichier **/
-  target_folder = BuildProdosFolderPath(current_image,target_folder_path,&is_volume_header,0);
+  target_folder = BuildProdosFolderPath(
+    current_image,
+    target_folder_path,
+    &is_volume_header,
+    current_entry->lowercase,
+    0
+  );
+
   if(target_folder == NULL && is_volume_header == 0)
     return;
 
@@ -80,7 +87,14 @@ void MoveProdosFolder(struct prodos_image *current_image, char *prodos_folder_pa
     }
 
   /** Recherche le dossier Prodos Cible où déplacer le dossier **/
-  target_folder = BuildProdosFolderPath(current_image,target_folder_path,&is_volume_header,0);
+  target_folder = BuildProdosFolderPath(
+    current_image,
+    target_folder_path,
+    &is_volume_header,
+    current_entry->lowercase,
+    0
+  );
+
   if(target_folder == NULL && is_volume_header == 0)
     return;
 

--- a/Src/os/os.h
+++ b/Src/os/os.h
@@ -25,6 +25,7 @@
 #include <sys/timeb.h>
 #include <sys/types.h>
 #include <time.h>
+#include <unistd.h>
 
 #ifdef BUILD_POSIX
 

--- a/Src/os/posix.c
+++ b/Src/os/posix.c
@@ -166,8 +166,6 @@ void os_GetFileCreationModificationDate(char *path, struct prodos_file *file) {
   file->file_creation_time = BuildProdosTime(time->tm_min, time->tm_hour);
   file->file_modification_date = BuildProdosDate(time->tm_mday, time->tm_mon + 1, time->tm_year + 1900);
   file->file_modification_time = BuildProdosTime(time->tm_min, time->tm_hour);
-
-  free(time);
 }
 
 

--- a/Src/os/posix.c
+++ b/Src/os/posix.c
@@ -80,39 +80,38 @@ int os_GetFolderFiles(char *folder_path, char *hierarchy)
     char *heap_path = calloc(1, strlen(folder_path) + 2);
     strcpy(heap_path, folder_path);
 
-    // If there's no trailing dir slash, we append it, and a glob
-    // (but no longer check for the Win-style terminator)
+    // If there's no trailing dir slash, we append it
     char last_char = heap_path[strlen(heap_path) - 1];
     if (last_char != '/') strcat(heap_path, FOLDER_CHARACTER);
 
-    // Most POSIX filename limits are 255 bytes.
-    char *heap_path_filename = calloc(1, strlen(folder_path) + 256);
-    strcpy(heap_path_filename, heap_path);
-
     // Append the filename to the path we copied earlier
-    strcat(heap_path_filename, entry->d_name);
+    strcat(heap_path, entry->d_name);
 
     // POSIX only guarantees that you'll have d_name,
     // so we're going to use the S_ISREG macro which is more reliable
     struct stat dirent_stat;
-    int staterr = stat(heap_path_filename, &dirent_stat);
+    int staterr = stat(heap_path, &dirent_stat);
     if (staterr) return(staterr);
 
     if (S_ISREG(dirent_stat.st_mode)) {
-      if (MatchHierarchie(heap_path_filename, hierarchy)){
-        my_Memory(MEMORY_ADD_FILE, heap_path_filename, NULL);
+      if (MatchHierarchie(heap_path, hierarchy)){
+        my_Memory(MEMORY_ADD_FILE, heap_path, NULL);
       }
     }
     else if (S_ISDIR(dirent_stat.st_mode)) {
       if (!my_stricmp(entry->d_name, ".") || !my_stricmp(entry->d_name, "..")) {
+        free(heap_path);
         continue;
       }
 
-      error = os_GetFolderFiles(heap_path_filename, hierarchy);
+      error = os_GetFolderFiles(heap_path, hierarchy);
       if (error) break;
     }
+
+    free(heap_path);
   }
 
+  free(dirstream);
   return error;
 }
 
@@ -167,6 +166,8 @@ void os_GetFileCreationModificationDate(char *path, struct prodos_file *file) {
   file->file_creation_time = BuildProdosTime(time->tm_min, time->tm_hour);
   file->file_modification_date = BuildProdosDate(time->tm_mday, time->tm_mon + 1, time->tm_year + 1900);
   file->file_modification_time = BuildProdosTime(time->tm_min, time->tm_hour);
+
+  free(time);
 }
 
 


### PR DESCRIPTION
Time has been scarce lately but I've been trying to make some progress. If anyone sees this and would like to lend an eye or two I'd greatly appreciate it as I don't write C every day (or frequently at all)

Things I am changing:
- I had introduced this weird global for managing toggles when I could have just reused `struct parameter`, so I've removed `struct globaltoggles` and moved things to `parameter`.
- Tried to fix all the warnings -- most of which appeared to be from implicit casts of `char *` to `unsigned char *` and vice versa. They're gone now and nothing seems broken. Famous last words!
- Case bits can now be toggled via `-C` for `ADDFILE`, `ADDFOLDER`, and `REPLACEFILE` actions.

#14 #24 #25 