### PR TITLE
Block device support

### DIFF
--- a/Src/Dc_Memory.h
+++ b/Src/Dc_Memory.h
@@ -49,6 +49,7 @@ struct parameter
   char *new_file_name;
   char *new_folder_name;
   char *new_volume_name;
+  int new_volume_format;
 
   char *new_file_path;
   char *new_folder_path;

--- a/Src/Dc_Memory.h
+++ b/Src/Dc_Memory.h
@@ -59,6 +59,7 @@ struct parameter
   char *folder_path;
 
   int verbose;
+
   bool output_apple_single;
   bool zero_case_bits;
 };

--- a/Src/Dc_Prodos.c
+++ b/Src/Dc_Prodos.c
@@ -251,7 +251,12 @@ int UpdateProdosImage(struct prodos_image *current_image)
         fseek(fd,(long)(i*BLOCK_SIZE+current_image->image_header_size),SEEK_SET);
 
         /* Ecrit le block */
-        nb_write = fwrite(&current_image->image_data[i*BLOCK_SIZE],1,BLOCK_SIZE,fd);
+        nb_write = fwrite(
+          &current_image->image_data[current_image->image_header_size + (i*BLOCK_SIZE)],
+          1,
+          BLOCK_SIZE,
+          fd
+        );
 
         /* Indique que c'est fait */
         current_image->block_modified[i] = 0;
@@ -756,7 +761,7 @@ void GetBlockData(struct prodos_image *current_image, int block_number, unsigned
     /* Récupère les data */
     memcpy(
       block_data_rtn,
-      &((current_image->image_data + current_image->image_header_size)[block_number*BLOCK_SIZE]),
+      &current_image->image_data[current_image->image_header_size + block_number*BLOCK_SIZE],
       BLOCK_SIZE
     );
   }
@@ -772,7 +777,11 @@ void SetBlockData(struct prodos_image *current_image, int block_number, unsigned
     return;
 
   /* Ecrit les data */
-  memcpy(&current_image->image_data[block_number*BLOCK_SIZE],block_data,BLOCK_SIZE);
+  memcpy(
+    &current_image->image_data[current_image->image_header_size + block_number*BLOCK_SIZE],
+    block_data,
+    BLOCK_SIZE
+  );
 
   /* Marque le block comme ayant été modifié */
   current_image->block_modified[block_number] = 1;

--- a/Src/Dc_Prodos.h
+++ b/Src/Dc_Prodos.h
@@ -55,6 +55,7 @@ struct prodos_time
 struct prodos_image
 {
   char *image_file_path;
+  int fd;
 
   int image_format;   /* 2mg, hdv, po*/
   int image_header_size;
@@ -297,6 +298,8 @@ struct prodos_file
 };
 
 struct prodos_image *LoadProdosImage(char *);
+struct prodos_image *LoadProdosDataFromFile(struct prodos_image *, char *);
+struct prodos_image *LoaddProdosDataFromBlock(struct prodos_image *, char *);
 struct file_descriptive_entry *ODSReadFileDescriptiveEntry(struct prodos_image *,char *,unsigned char *);
 int UpdateProdosImage(struct prodos_image *);
 struct file_descriptive_entry *GetProdosFile(struct prodos_image *,char *);

--- a/Src/Dc_Prodos.h
+++ b/Src/Dc_Prodos.h
@@ -302,7 +302,6 @@ struct prodos_file
 struct prodos_image *LoadProdosImage(char *);
 struct prodos_image *DetectImageType(struct prodos_image *);
 struct prodos_image *LoadProdosDataFromFile(struct prodos_image *, char *);
-struct prodos_image *LoadProdosDataFromBlock(struct prodos_image *, char *);
 struct file_descriptive_entry *ODSReadFileDescriptiveEntry(struct prodos_image *,char *,unsigned char *);
 int UpdateProdosImage(struct prodos_image *);
 struct file_descriptive_entry *GetProdosFile(struct prodos_image *,char *);

--- a/Src/Dc_Prodos.h
+++ b/Src/Dc_Prodos.h
@@ -299,7 +299,7 @@ struct prodos_file
 
 struct prodos_image *LoadProdosImage(char *);
 struct prodos_image *LoadProdosDataFromFile(struct prodos_image *, char *);
-struct prodos_image *LoaddProdosDataFromBlock(struct prodos_image *, char *);
+struct prodos_image *LoadProdosDataFromBlock(struct prodos_image *, char *);
 struct file_descriptive_entry *ODSReadFileDescriptiveEntry(struct prodos_image *,char *,unsigned char *);
 int UpdateProdosImage(struct prodos_image *);
 struct file_descriptive_entry *GetProdosFile(struct prodos_image *,char *);

--- a/Src/Dc_Prodos.h
+++ b/Src/Dc_Prodos.h
@@ -8,17 +8,19 @@
 
 #pragma once
 
-#define IMG_HEADER_SIZE  0x40   /* 2MG Header Size */
-#define HDV_HEADER_SIZE  0x00   /* HDV Header Size */
-#define  PO_HEADER_SIZE  0x00   /*  PO Header Size */
+#define IMG_HEADER_SIZE  0x40         /* 2MG Header Size */
+#define IMG_HEADER_MAGIC 0x32494D47
+
+#define HDV_HEADER_SIZE  0x00         /* HDV Header Size */
+#define  PO_HEADER_SIZE  0x00         /*  PO Header Size */
 
 #define IMAGE_UNKNOWN       0
-#define IMAGE_2MG           1   /* 2MG */
-#define IMAGE_HDV           2   /* HDV */
-#define IMAGE_PO            3   /*  PO */
+#define IMAGE_2MG           1         /* 2MG */
+#define IMAGE_HDV           2         /* HDV */
+#define IMAGE_PO            3         /*  PO */
 
-#define BLOCK_SIZE       512    /* Taille d'un block */
-#define INDEX_PER_BLOCK  256    /* Nombre d'index de block dans un block */
+#define BLOCK_SIZE       512          /* Taille d'un block */
+#define INDEX_PER_BLOCK  256          /* Nombre d'index de block dans un block */
 
 #define UPDATE_ADD     1
 #define UPDATE_REMOVE  2
@@ -298,6 +300,7 @@ struct prodos_file
 };
 
 struct prodos_image *LoadProdosImage(char *);
+struct prodos_image *DetectImageType(struct prodos_image *);
 struct prodos_image *LoadProdosDataFromFile(struct prodos_image *, char *);
 struct prodos_image *LoadProdosDataFromBlock(struct prodos_image *, char *);
 struct file_descriptive_entry *ODSReadFileDescriptiveEntry(struct prodos_image *,char *,unsigned char *);

--- a/Src/File_AppleSingle.h
+++ b/Src/File_AppleSingle.h
@@ -18,7 +18,6 @@
 #include "Dc_Prodos.h"
 
 const unsigned static int AS_MAGIC;
-#define IS_LITTLE_ENDIAN 'APPL' == (uint32_t) 0x4150504C
 
 #pragma pack(push, 1)
 

--- a/Src/Main.c
+++ b/Src/Main.c
@@ -517,6 +517,10 @@ int main(int argc, char *argv[])
       mem_free_list(nb_filepath,filepath_tab);
     }
 
+  if (current_image->fd != -1) {
+    close(current_image->fd);
+  }
+
   /* Libération mémoire */
   mem_free_param(param);
   my_Memory(MEMORY_FREE,NULL,NULL);

--- a/Src/Main.c
+++ b/Src/Main.c
@@ -361,6 +361,7 @@ int main(int argc, char *argv[])
         param->image_file_path,
         param->new_volume_name,
         param->new_volume_size_kb,
+        param->new_volume_format,
         param->zero_case_bits
       );
 
@@ -580,6 +581,28 @@ void apply_command_flags(struct parameter *params, int start, int argc, char **a
     ) {
       params->zero_case_bits = true;
     }
+    else if (
+      params->action == ACTION_CREATE_VOLUME && (
+        strstr(argv[i], "-F") ||
+        strstr(argv[i], "--format")
+      )
+    ) {
+      char *format = strchr(argv[i], '=');
+
+      if (format) format++;
+      else if (!format && (i+1) < argc)
+        format = argv[i + 1];
+
+      if (!my_stricmp(format, "2mg")) {
+        params->new_volume_format = IMAGE_2MG;
+      }
+      else if (!my_stricmp(format, "hdv")) {
+        params->new_volume_format = IMAGE_HDV;
+      }
+      else if (!my_stricmp(format, "po")) {
+        params->new_volume_format = IMAGE_PO;
+      }
+    }
   }
 }
 
@@ -625,6 +648,7 @@ void usage(char *program_path)
   logf("        %s CREATEFOLDER  <[2mg|hdv|po]_image_path>   <prodos_folder_path>\n",program_path);
   logf("        [-C | --no-case-bits]\n");
   logf("        %s CREATEVOLUME  <[2mg|hdv|po]_image_path>   <volume_name>         <volume_size>\n",program_path);
+  logf("        [-F | --format 2mg|hdv|po] If image path is a block device, format must be specified.\n");
   logf("        [-C | --no-case-bits]\n");
   logf("        ----\n");
   logf("        %s CLEARHIGHBIT  <source_file_path>\n",program_path);

--- a/Src/Prodos_Create.c
+++ b/Src/Prodos_Create.c
@@ -104,22 +104,22 @@ struct prodos_image *CreateProdosVolume(
   if (os_IsBlockDevice(image_file_path)) {
     block_fd = os_OpenBlockFd(image_file_path);
 
+
     /* If writing to a block device, check to see that the image can fit */
-    // if (block_fd != -1)
-    // {
-    //   lseek(block_fd, 0, SEEK_SET);
-    //   const off_t target_size = lseek(block_fd, 0, SEEK_END);
-    //   if (target_size < 0 || (target_size / 1024) < volume_size_kb)
-    //   {
-    //     logf_error(
-    //       "   Error : Target device too small %s\n    %i / %i",
-    //       image_file_path,
-    //       volume_size_kb,
-    //       target_size / 1024
-    //     );
-    //     return (NULL);
-    //   }
-    // }
+    if (block_fd != -1)
+    {
+      const uint64_t target_size_kb = os_GetBlockDeviceSizeKB(block_fd);
+      if (target_size_kb < 0 || (target_size_kb < volume_size_kb))
+      {
+        logf_error(
+          "   Error : Target device too small %s\n    %i / %i\n",
+          image_file_path,
+          volume_size_kb,
+          target_size_kb
+        );
+        return (NULL);
+      }
+    }
   }
 
   /** Type d'image **/

--- a/Src/Prodos_Create.h
+++ b/Src/Prodos_Create.h
@@ -7,7 +7,7 @@
 /**********************************************************************/
 
 void CreateProdosFolder(struct prodos_image *,char *,bool);
-struct prodos_image *CreateProdosVolume(char *,char *,int,bool);
+struct prodos_image *CreateProdosVolume(char *,char *,int,int,bool);
 struct file_descriptive_entry *CreateOneProdosFolder(struct prodos_image *,struct file_descriptive_entry *,char *,bool,int);
 struct file_descriptive_entry *BuildProdosFolderPath(struct prodos_image *,char *,int *,bool,int);
 

--- a/Src/os/os.c
+++ b/Src/os/os.c
@@ -95,3 +95,24 @@ int os_OpenBlockFd(char *path)
 
 	return fd;
 }
+
+uint64_t os_GetBlockDeviceSizeKB(int fd) {
+	uint32_t block_size;
+	uint64_t size;
+
+	#ifdef __APPLE__
+	ioctl(fd, DKIOCGETBLOCKSIZE, &block_size);
+	ioctl(fd, DKIOCGETBLOCKCOUNT, &size);
+	#endif
+	#ifdef __linux__
+	ioctl(fd, BLKPBSZGET, &block_size);
+	ioctl(fd, BLKGETSIZE, &size);
+	#endif
+	// BSD
+	#ifdef DIOCGMEDIASIZE
+	ioctl(fd, DIOCGMEDIASIZE, &size);
+	block_size = 1;
+	#endif
+
+	return (size * block_size) >> 10;
+}

--- a/Src/os/os.c
+++ b/Src/os/os.c
@@ -10,6 +10,9 @@
  */
 
 #include "os.h"
+#include "../log.h"
+
+extern int errno;
 
 /**
 * Delete file at path
@@ -71,4 +74,24 @@ bool os_IsBlockDevice(char *path)
 	struct stat path_stat;
 	if (stat(path, &path_stat)) return false;
 	return S_ISBLK(path_stat.st_mode);
+}
+
+/**
+ * @brief Open fd to a block device
+ * 
+ * @param path 
+ * @return int 
+ */
+int os_OpenBlockFd(char *path)
+{
+	// TODO: use O_RDONLY for CATALOG, O_RDWR for any modifications
+	const int fd = open(path, O_RDWR);
+
+	if (fd == -1)
+	{
+		logf_error("  Error: Unable to open block device %s (%s)\n", path, strerror(errno));
+		return fd;
+	}
+
+	return fd;
 }

--- a/Src/os/os.c
+++ b/Src/os/os.c
@@ -58,3 +58,17 @@ int os_CreateDirectory(char *directory)
 
 	return error;
 }
+
+/**
+ * Checks to see if the provided path is for a block device.
+ * 
+ * @param path 
+ * @return true 
+ * @return false 
+ */
+bool os_IsBlockDevice(char *path)
+{
+	struct stat path_stat;
+	if (stat(path, &path_stat)) return false;
+	return S_ISBLK(path_stat.st_mode);
+}

--- a/Src/os/os.h
+++ b/Src/os/os.h
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#include <errno.h>
 
 #ifdef BUILD_POSIX
 
@@ -68,6 +69,7 @@ void os_SetFileCreationModificationDate(char *,struct file_descriptive_entry *);
 void os_GetFileCreationModificationDate(char *,struct prodos_file *);
 void os_SetFileAttribute(char *,int);
 bool os_IsBlockDevice(char *);
+int os_OpenBlockFd(char *);
 int my_stricmp(char *,char *);
 int my_strnicmp(char *,char *,size_t);
 int my_mkdir(char *path);

--- a/Src/os/os.h
+++ b/Src/os/os.h
@@ -34,6 +34,9 @@
 
 #include <dirent.h>
 #include <utime.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/disk.h>
 
 #endif
 
@@ -70,6 +73,7 @@ void os_GetFileCreationModificationDate(char *,struct prodos_file *);
 void os_SetFileAttribute(char *,int);
 bool os_IsBlockDevice(char *);
 int os_OpenBlockFd(char *);
+uint64_t os_GetBlockDeviceSizeKB(int);
 int my_stricmp(char *,char *);
 int my_strnicmp(char *,char *,size_t);
 int my_mkdir(char *path);

--- a/Src/os/os.h
+++ b/Src/os/os.h
@@ -67,6 +67,7 @@ void os_DeleteFile(char *file_path);
 void os_SetFileCreationModificationDate(char *,struct file_descriptive_entry *);
 void os_GetFileCreationModificationDate(char *,struct prodos_file *);
 void os_SetFileAttribute(char *,int);
+bool os_IsBlockDevice(char *);
 int my_stricmp(char *,char *);
 int my_strnicmp(char *,char *,size_t);
 int my_mkdir(char *path);

--- a/Src/os/posix.c
+++ b/Src/os/posix.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include "os.h" 
+#include "os.h"
 
 #ifdef BUILD_POSIX
 
@@ -167,7 +167,6 @@ void os_GetFileCreationModificationDate(char *path, struct prodos_file *file) {
   file->file_modification_date = BuildProdosDate(time->tm_mday, time->tm_mon + 1, time->tm_year + 1900);
   file->file_modification_time = BuildProdosTime(time->tm_min, time->tm_hour);
 }
-
 
 char *my_strcpy(char *s1, char *s2) 
 {


### PR DESCRIPTION
When moving stuff to my IIgs, I would always `dd` the image off of a CF card, make an edit using CADIUS, and then `dd` it back. I would like to be able to use block devices directly to avoid doing this. 

Changes:
- `struct prodos_image` has an `fd` field
  - `GetBlockData` `SetBlockData` use it if it is set
- Image format by reading image headers (we scan for `2IMG` as the first four bytes for a `.2mg` image)
- Clean up AppleSingle endian-swap stuff / move to `ntohl/s`

Usage:
For each command that takes `<[2mg|hdv|po]_image_path>`, you may substitute with a path to a block device.