### PR TITLE
Changes to support reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/bin/
+/build/
+/cadius

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Any and all contributions are welcome. Included is also a `cadius.pro` file you 
 
 ## Changelog
 
+#### 1.4.6
+- Fix ADDFILE erroneously making the first block of a file sparse (thanks [@inexorabletash](https://github.com/inexorabletash)). [#43](https://github.com/mach-kernel/cadius/pull/43)
+
 #### 1.4.5
 - Fix `os_GetFolderFiles` calloc too small.
 - AppleSingle check for OOB accesses (thanks [@peterferrie](https://github.com/peterferrie)). [#34](https://github.com/mach-kernel/cadius/pull/34)

--- a/Src/Dc_Prodos.c
+++ b/Src/Dc_Prodos.c
@@ -1090,6 +1090,9 @@ static int GetFileDataResourceSize(struct prodos_image *current_image, struct fi
             if(tab_block[i] == 0)
               file_entry->nb_sparse++;
 
+          if(tab_block[0] == 0)
+            logf_error("  Warning : Block 0 is sparse in file: '%s'.\n", file_entry->file_path);
+
           /* Table des blocs utilisés */
           file_entry->tab_used_block = BuildUsedBlockTable(nb_block,tab_block,nb_index_block,tab_index_block,&file_entry->nb_used_block);
           if(file_entry->tab_used_block == NULL)
@@ -1180,6 +1183,9 @@ static int GetFileDataResourceSize(struct prodos_image *current_image, struct fi
             if(tab_block[i] == 0)
               file_entry->nb_sparse++;
 
+          if(tab_block[0] == 0)
+            logf_error("  Warning : Block 0 is sparse in data fork of file: '%s'.\n", file_entry->file_path);
+
           /* Table des blocs utilisés (Data) */
           tab_used_block_data = BuildUsedBlockTable(nb_block,tab_block,nb_index_block,tab_index_block,&nb_used_block_data);
           if(tab_used_block_data == NULL)
@@ -1249,6 +1255,9 @@ static int GetFileDataResourceSize(struct prodos_image *current_image, struct fi
           for(i=0; i<nb_block; i++)
             if(tab_block[i] == 0)
               file_entry->nb_sparse++;
+
+          if(tab_block[0] == 0)
+            logf_error("  Warning : Block 0 is sparse in resource fork of file: '%s'.\n", file_entry->file_path);
 
           /* Table des blocs utilisés (Resource) */
           tab_used_block_resource = BuildUsedBlockTable(nb_block,tab_block,nb_index_block,tab_index_block,&nb_used_block_resource);

--- a/Src/Dc_Prodos.c
+++ b/Src/Dc_Prodos.c
@@ -463,7 +463,7 @@ static void GetAllDirectoryFile(struct prodos_image *current_image)
   first_directory = NULL;
   sprintf(volume_path,"/%s",current_image->volume_header->volume_name_case);
 
-  /*******************************************/  
+  /*******************************************/
   /**  Volume Directory (Block 2+suivants)  **/
   block_number = 2;
   GetBlockData(current_image,block_number,one_block);
@@ -729,13 +729,13 @@ WORD BuildProdosDate(int day, int month, int year)
 {
   WORD prodos_date;
   int prodos_year;
-  
+
   /* Création de la Date */
   prodos_year = year - 1900;
   if(prodos_year > 100)
     prodos_year -= 100;
   prodos_date = ((prodos_year << 9) & 0xFE00) | ((month << 5) & 0x01E0) | (day & 0x001F);
-  
+
   /* Renvoie la date */
   return(prodos_date);
 }
@@ -765,7 +765,7 @@ static void BuildLowerCase(char *file_name, WORD lowercase, char *file_name_case
 
   /* Init */
   strcpy(file_name_case_rtn,file_name);
-  
+
   /* Vérifie la présence du 0x8000 */
   if((lowercase & 0x8000) == 0x0000)
     return;
@@ -1080,7 +1080,7 @@ static int GetFileDataResourceSize(struct prodos_image *current_image, struct fi
                   return(1);
                 }
             }
-          else 
+          else
             {
               nb_block = 0;
             }
@@ -1168,7 +1168,7 @@ static int GetFileDataResourceSize(struct prodos_image *current_image, struct fi
                   return(1);
                 }
             }
-          else 
+          else
             {
               nb_block = 0;
               index_block = 0;
@@ -1501,7 +1501,7 @@ struct file_descriptive_entry *GetProdosFile(struct prodos_image *current_image,
         }
       else if(is_root_name == 1)
         {
-          /* Nom du Dossier à la racine */ 
+          /* Nom du Dossier à la racine */
           if(begin != NULL)
             {
               for(i=0; i<current_image->nb_directory; i++)
@@ -1638,7 +1638,7 @@ struct file_descriptive_entry *GetProdosFolder(struct prodos_image *current_imag
         }
       else if(is_root_name == 1)
         {
-          /* Nom du Dossier à la racine */ 
+          /* Nom du Dossier à la racine */
           for(i=0; i<current_image->nb_directory; i++)
             if(!my_stricmp(current_image->tab_directory[i]->file_name,name))
               {
@@ -1961,7 +1961,7 @@ int *AllocateImageBlock(struct prodos_image *current_image, int nb_block)
   /* Pas assez de place ! */
   if(current_image->nb_free_block < nb_block)
     {
-      logf_error("  Error : Impossible to allocate %d blocks. No space left on image.\n",nb_block);  
+      logf_error("  Error : Impossible to allocate %d blocks. No space left on image.\n",nb_block);
       return(NULL);
     }
 
@@ -2198,14 +2198,22 @@ int CheckProdosName(char *name)
 void GetCurrentDate(WORD *now_date_rtn, WORD *now_time_rtn)
 {
   time_t clock;
+  struct tm source_date_epoch_tm;
   struct tm *p;
   WORD now_date, now_time;
   WORD year, month, day;
   WORD hour, minute;
 
-  /* Récupère l'heure actuelle */
-  time(&clock);
-  p = localtime(&clock);
+  char* source_date_epoch_env = getenv("SOURCE_DATE_EPOCH");
+  if (source_date_epoch_env) {
+    /* get time from environment variable (for reproducible builds) */
+    strptime(source_date_epoch_env, "%s", &source_date_epoch_tm);
+    p = &source_date_epoch_tm;
+  } else {
+    /* Récupère l'heure actuelle */
+    time(&clock);
+    p = localtime(&clock);
+  }
   year = (WORD) p->tm_year;
   if(year > 100)
     year -= 100;
@@ -2386,7 +2394,7 @@ void mem_free_file(struct prodos_file *current_file)
 
       if(current_file->file_name_case)
         free(current_file->file_name_case);
-        
+
       if(current_file->tab_data_block)
         free(current_file->tab_data_block);
 

--- a/Src/Main.c
+++ b/Src/Main.c
@@ -60,6 +60,13 @@
 #define ACTION_INDENT_FILE       82
 #define ACTION_OUTDENT_FILE      83
 
+#define ERROR_HELP                1
+#define ERROR_PARAM               2
+#define ERROR_LOAD                3
+#define ERROR_GET                 4
+#define ERROR_EXTRACT             5
+#define ERROR_ADD                 6
+
 int apply_global_flags(struct parameter*, int, char**);
 void apply_command_flags(struct parameter*, int, int, char**);
 void usage(char *);
@@ -70,7 +77,7 @@ struct parameter *GetParamLine(int,char *[]);
 /****************************************************/
 int main(int argc, char *argv[])
 {
-  int i, nb_filepath;
+  int i, nb_filepath, application_error=0;
   char **filepath_tab;
   struct parameter *param;
   struct prodos_image *current_image;
@@ -83,7 +90,7 @@ int main(int argc, char *argv[])
   if(argc < 3)
     {
       usage(argv[0]);
-      return(1);
+      return(ERROR_HELP);
     }
 
   /* Initialisation */
@@ -92,7 +99,7 @@ int main(int argc, char *argv[])
   /** Décode les paramètres **/
   param = GetParamLine(argc, argv);
   if(param == NULL)
-    return(2);
+    return(ERROR_PARAM);
 
   /** Actions **/
   if(param->action == ACTION_CATALOG)
@@ -103,7 +110,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /** Affichage du contenu de l'image **/
       DumpProdosImage(current_image,param->verbose);
@@ -119,7 +126,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /** Affichage des informations sur le contenu de l'image **/
       CheckProdosImage(current_image,param->verbose);
@@ -136,7 +143,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /** Extrait le fichier sur disque **/
       ExtractOneFile(
@@ -158,12 +165,12 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /** Recherche l'entrée du dossier **/
       folder_entry = GetProdosFolder(current_image,param->prodos_folder_path,1);
       if(folder_entry == NULL)
-        return(4);
+        return(ERROR_GET);
 
       /** Extrait les fichiers du répertoire **/
       ExtractFolderFiles(
@@ -175,6 +182,7 @@ int main(int argc, char *argv[])
 
       /* Stat */
       logf("    => File(s) : %d,  Folder(s) : %d,  Error(s) : %d\n",current_image->nb_extract_file,current_image->nb_extract_folder,current_image->nb_extract_error);
+      if (current_image->nb_extract_error > 0) application_error = ERROR_EXTRACT;
 
       /* Libération mémoire */
       mem_free_image(current_image);
@@ -184,7 +192,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Extract volume '%s' :\n",current_image->volume_header->volume_name_case);
@@ -199,6 +207,7 @@ int main(int argc, char *argv[])
 
       /* Stat */
       logf("    => File(s) : %d,  Folder(s) : %d,  Error(s) : %d\n",current_image->nb_extract_file,current_image->nb_extract_folder,current_image->nb_extract_error);
+      if (current_image->nb_extract_error > 0) application_error = ERROR_EXTRACT;
 
       /* Libération mémoire */
       mem_free_image(current_image);
@@ -208,7 +217,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Rename file '%s' as '%s' :\n",param->prodos_file_path,param->new_file_name);
@@ -224,7 +233,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Rename folder '%s' as '%s' :\n",param->prodos_folder_path,param->new_folder_name);
@@ -240,7 +249,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Rename volume '%s' as '%s' :\n",current_image->volume_header->volume_name_case,param->new_volume_name);
@@ -256,7 +265,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Move file '%s' to folder '%s' :\n",param->prodos_file_path,param->new_file_path);
@@ -272,7 +281,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Move folder '%s' to '%s' :\n",param->prodos_folder_path,param->new_folder_path);
@@ -288,7 +297,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Delete file '%s' :\n",param->prodos_file_path);
@@ -304,7 +313,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Delete folder '%s' :\n",param->prodos_folder_path);
@@ -320,7 +329,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Delete volume '%s' :\n",current_image->volume_header->volume_name_case);
@@ -336,7 +345,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Create folder '%s' :\n",param->prodos_folder_path);
@@ -365,7 +374,7 @@ int main(int argc, char *argv[])
       );
 
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Libération mémoire */
       mem_free_image(current_image);
@@ -375,7 +384,7 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Add file '%s' :\n",param->file_path);
@@ -388,6 +397,7 @@ int main(int argc, char *argv[])
         param->zero_case_bits,
         1
       );
+      if (current_image->nb_add_error > 0) application_error = ERROR_ADD;
 
       /* Libération mémoire */
       mem_free_image(current_image);
@@ -397,13 +407,14 @@ int main(int argc, char *argv[])
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       /* Information */
       logf_info("  - Add folder '%s' :\n",param->folder_path);
 
       /** Ajoute l'ensemble des fichiers du répertoire dans l'archive **/
       AddFolder(current_image,param->folder_path,param->prodos_folder_path,param->zero_case_bits);
+      if (current_image->nb_add_error > 0) application_error = ERROR_ADD;
 
       /* Stat */
       logf("    => File(s) : %d,  Folder(s) : %d,  Error(s) : %d\n",current_image->nb_add_file,current_image->nb_add_folder,current_image->nb_add_error);
@@ -411,12 +422,12 @@ int main(int argc, char *argv[])
       /* Libération mémoire */
       mem_free_image(current_image);
     }
-  else if(param->action == ACTION_REPLACE_FILE) 
+  else if(param->action == ACTION_REPLACE_FILE)
     {
       /** Charge l'image 2mg **/
       current_image = LoadProdosImage(param->image_file_path);
       if(current_image == NULL)
-        return(3);
+        return(ERROR_LOAD);
 
       int fcharloc = 0;
       for (int i=strlen(param->file_path); i >= 0; --i) {
@@ -445,13 +456,14 @@ int main(int argc, char *argv[])
       DeleteProdosFile(current_image, prodos_file_name);
       log_on();
 
-      AddFile(
+      int add_error = AddFile(
         current_image,
         param->file_path,
         param->prodos_folder_path,
         param->zero_case_bits,
         1
       );
+      if (add_error != 0) application_error = ERROR_ADD;
 
       free(prodos_file_name);
       mem_free_image(current_image);
@@ -521,23 +533,23 @@ int main(int argc, char *argv[])
   mem_free_param(param);
   my_Memory(MEMORY_FREE,NULL,NULL);
 
-  /* OK */              
-  return(0);
+  /* return final error code, if any */
+  return(application_error);
 }
 
 /**
  * Parse tail end of args and toggle global settings
- * 
- * @param argc 
- * @param args 
+ *
+ * @param argc
+ * @param args
  */
-int apply_global_flags(struct parameter *params, int argc, char **argv) 
+int apply_global_flags(struct parameter *params, int argc, char **argv)
 {
   int found = 0;
 
-  for (int i=3; i < argc; ++i) 
+  for (int i=3; i < argc; ++i)
   {
-    if (!my_stricmp(argv[i], "--quiet")) 
+    if (!my_stricmp(argv[i], "--quiet"))
     {
       log_set_level(ERROR);
       found += 1;
@@ -549,7 +561,7 @@ int apply_global_flags(struct parameter *params, int argc, char **argv)
       found += 1;
     }
 
-    if (!my_stricmp(argv[i], "-A")) 
+    if (!my_stricmp(argv[i], "-A"))
     {
       params -> output_apple_single = true;
       found += 1;
@@ -1199,7 +1211,7 @@ struct parameter *GetParamLine(int argc, char *argv[])
       /* OK */
       return(param);
     }
-  
+
   /* Action inconnue */
   usage(argv[0]);
 

--- a/Src/Main.c
+++ b/Src/Main.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
   struct file_descriptive_entry *folder_entry;
 
   /* Message Information */
-  logf("%s v 1.4.5 (c) Brutal Deluxe 2011-2013.\n",argv[0]);
+  logf("%s v 1.4.6 (c) Brutal Deluxe 2011-2013.\n",argv[0]);
 
   /* Vérification des paramètres */
   if(argc < 3)

--- a/Src/Prodos_Add.c
+++ b/Src/Prodos_Add.c
@@ -82,7 +82,7 @@ int AddFile(
       current_image->nb_add_error++;
       mem_free_file(current_file);
       return(1);
-    } 
+    }
 
   /** Calcule le nombre de block nécessaire pour stocker le fichier (gestion du Sparse) **/
   ComputeFileBlockUsage(current_file);
@@ -173,7 +173,7 @@ int AddFile(
     }
 
   /*** Création du contenu fichier (index+data+resource) ***/
-  file_block_number = CreateFileContent(current_image,current_file);  
+  file_block_number = CreateFileContent(current_image,current_file);
   if(file_block_number == 0)
     {
       current_image->nb_add_error++;
@@ -196,7 +196,7 @@ int AddFile(
 
   /* Libération mémoire */
   mem_free_file(current_file);
-    
+
   /** Ecrit le fichier Image **/
   if(update_image)
     error = UpdateProdosImage(current_image);
@@ -212,10 +212,10 @@ int AddFile(
 /********************************************************************************/
 void AddFolder(struct prodos_image *current_image, char *folder_path, char *target_folder_path, bool zero_case_bits)
 {
-  int i, j, error, is_volume_header;
+  int i, j, is_volume_header;
   int nb_file;
   char **tab_file;
-  struct file_descriptive_entry *target_folder;  
+  struct file_descriptive_entry *target_folder;
   char full_folder_path[1024];
   char prodos_folder_path[1024];
 
@@ -256,7 +256,7 @@ void AddFolder(struct prodos_image *current_image, char *folder_path, char *targ
       if(strlen(tab_file[i]) > strlen("_FileInformation.txt"))
         if(!my_stricmp(&tab_file[i][strlen(tab_file[i])-strlen("_FileInformation.txt")],"_FileInformation.txt"))
           continue;
-      
+
       /** Chemin Prodos du fichier dans l'image **/
       strcpy(prodos_folder_path,target_folder_path);
       if(prodos_folder_path[strlen(prodos_folder_path)-1] != '/')
@@ -277,16 +277,16 @@ void AddFolder(struct prodos_image *current_image, char *folder_path, char *targ
             prodos_folder_path[j+1] = '\0';
             break;
           }
-      
+
       /** Ajoute ce fichier à l'archive **/
-      error = AddFile(current_image,tab_file[i],prodos_folder_path,zero_case_bits,0);
+      AddFile(current_image,tab_file[i],prodos_folder_path,zero_case_bits,0);
     }
 
   /* Libération table des fichiers */
   mem_free_list(nb_file,tab_file);
 
   /** Ecrit le fichier Image **/
-  error = UpdateProdosImage(current_image);  
+  UpdateProdosImage(current_image);
 }
 
 
@@ -358,7 +358,7 @@ static struct prodos_file *LoadFile(char *file_path_data, bool zero_case_bits)
   // Load data. If an AppleSingle file, parse it.
   unsigned char *data = LoadBinaryFile(file_path_data, &current_file->data_length);
 
-  if (data == NULL) 
+  if (data == NULL)
   {
     logf_error("  Error : Cannot load file %s\n", file_path_data);
     return NULL;
@@ -427,7 +427,7 @@ static struct prodos_file *LoadFile(char *file_path_data, bool zero_case_bits)
 
 
 /********************************************************************/
-/*  GetFileInformation() :  Récupère les informations d'un fichier. */ 
+/*  GetFileInformation() :  Récupère les informations d'un fichier. */
 /********************************************************************/
 static int GetFileInformation(char *file_information_path, char *file_name, struct prodos_file *current_file)
 {
@@ -502,7 +502,7 @@ static int GetFileInformation(char *file_information_path, char *file_name, stru
                 sscanf(&local_buffer[2*j],"%2X",&value);
                 current_file->resource_finderinfo_2[j] = (unsigned char) value;
               }
-            
+
           /* Trouvé */
           mem_free_list(nb_line,line_tab);
           return(1);
@@ -552,14 +552,14 @@ static void ComputeFileBlockUsage(struct prodos_file *current_file)
 {
   int i, result;
   unsigned char empty_block[BLOCK_SIZE];
-  
+
   /* Init */
   memset(empty_block,0x00,BLOCK_SIZE);
   current_file->block_disk_data = 0;      /* Nb de blocks disk utilisés pour les data */
   current_file->empty_data = 0;           /* Tout est à zéro */
   current_file->block_disk_resource = 0;  /* Nb de blocks disk utilisés pour les resource */
   current_file->empty_resource = 0;       /* Tout est à zéro */
-  
+
   /** Nombre de block pour les Data **/
   current_file->block_data = GetContainerNumber(current_file->data_length,BLOCK_SIZE);
   for(i=0; i<current_file->data_length; i+=BLOCK_SIZE)
@@ -569,7 +569,7 @@ static void ComputeFileBlockUsage(struct prodos_file *current_file)
         result = memcmp(&current_file->data[i],empty_block,BLOCK_SIZE);
       else
         result = memcmp(&current_file->data[i],empty_block,current_file->data_length-i);
-        
+
       /* Block à réserver ? */
       current_file->block_disk_data += (result == 0) ? 0 : 1;
     }
@@ -590,7 +590,7 @@ static void ComputeFileBlockUsage(struct prodos_file *current_file)
             result = memcmp(&current_file->resource[i],empty_block,BLOCK_SIZE);
           else
             result = memcmp(&current_file->resource[i],empty_block,current_file->resource_length-i);
-            
+
           /* Block à réserver ? */
           current_file->block_disk_resource += (result == 0) ? 0 : 1;
         }
@@ -764,7 +764,7 @@ static WORD CreateFileContent(struct prodos_image *current_image, struct prodos_
         }
       else
         {
-          return(1); 
+          return(1);
         }
 
       /** Remplissage de l'Extended block **/
@@ -887,7 +887,7 @@ static WORD CreateSaplingContent(struct prodos_image *current_image, struct prod
         is_empty = !memcmp(&data[i],empty_block,BLOCK_SIZE);
       else
         is_empty = !memcmp(&data[i],empty_block,data_length-i);
-        
+
       /* Numéro du block */
       if(is_data)
         data_block_number = (is_empty == 1) ? 0 : current_file->tab_data_block[j++];
@@ -1010,7 +1010,7 @@ static WORD CreateTreeContent(struct prodos_image *current_image, struct prodos_
         is_empty = !memcmp(&data[i],empty_block,BLOCK_SIZE);
       else
         is_empty = !memcmp(&data[i],empty_block,data_length-i);
-        
+
       /* Numéro du block */
       data_block_number = (is_empty == 1) ? 0 : ((is_data) ? current_file->tab_data_block[j++] : current_file->tab_resource_block[j++]);
 

--- a/Src/Prodos_Add.c
+++ b/Src/Prodos_Add.c
@@ -565,7 +565,9 @@ static void ComputeFileBlockUsage(struct prodos_file *current_file)
   for(i=0; i<current_file->data_length; i+=BLOCK_SIZE)
     {
       /* Recherche les plages de 0 */
-      if(i+BLOCK_SIZE <= current_file->data_length)
+      if(i == 0)
+        result = 1; /* Block 0 ne doit pas être Sparse */
+      else if(i+BLOCK_SIZE <= current_file->data_length)
         result = memcmp(&current_file->data[i],empty_block,BLOCK_SIZE);
       else
         result = memcmp(&current_file->data[i],empty_block,current_file->data_length-i);
@@ -586,7 +588,9 @@ static void ComputeFileBlockUsage(struct prodos_file *current_file)
       for(i=0; i<current_file->resource_length; i+=BLOCK_SIZE)
         {
           /* Recherche les plages de 0 */
-          if(i+BLOCK_SIZE <= current_file->resource_length)
+          if(i == 0)
+            result = 1; /* Block 0 ne doit pas être Sparse */
+          else if(i+BLOCK_SIZE <= current_file->resource_length)
             result = memcmp(&current_file->resource[i],empty_block,BLOCK_SIZE);
           else
             result = memcmp(&current_file->resource[i],empty_block,current_file->resource_length-i);
@@ -883,7 +887,9 @@ static WORD CreateSaplingContent(struct prodos_image *current_image, struct prod
   for(i=0,j=1,k=0; i<data_length; i+=BLOCK_SIZE,k++)
     {
       /* Recherche les plages de 0 */
-      if(i+BLOCK_SIZE <= data_length)
+      if(i == 0)
+        is_empty = 0; /* Block 0 ne doit pas être Sparse */
+      else if(i+BLOCK_SIZE <= data_length)
         is_empty = !memcmp(&data[i],empty_block,BLOCK_SIZE);
       else
         is_empty = !memcmp(&data[i],empty_block,data_length-i);
@@ -1006,7 +1012,9 @@ static WORD CreateTreeContent(struct prodos_image *current_image, struct prodos_
   for(i=0,j=index_data,k=0,l=0; i<data_length; i+=BLOCK_SIZE,k++)
     {
       /* Recherche les plages de 0 */
-      if(i+BLOCK_SIZE <= data_length)
+      if(i == 0)
+        is_empty = 0; /* Block 0 ne doit pas être Sparse */
+      else if(i+BLOCK_SIZE <= data_length)
         is_empty = !memcmp(&data[i],empty_block,BLOCK_SIZE);
       else
         is_empty = !memcmp(&data[i],empty_block,data_length-i);

--- a/Src/os/posix.c
+++ b/Src/os/posix.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include "os.h" 
+#include "os.h"
 
 #ifdef BUILD_POSIX
 
@@ -66,14 +66,15 @@ int my_strnicmp(char *string1, char *string2, size_t length)
  */
 int os_GetFolderFiles(char *folder_path, char *hierarchy)
 {
+  struct dirent **entrylist;
+  struct dirent *entry;
+  int count, i;
   int error = 0;
   if (folder_path == NULL || strlen(folder_path) == 0) return(0);
-
-  DIR *dirstream = opendir(folder_path);
-  if (dirstream == NULL) return(1);
-
-  while(dirstream != NULL) {
-    struct dirent *entry = readdir(dirstream);
+  count = scandir(folder_path, &entrylist, NULL, alphasort);
+  if (count < 0) return(1);
+  for (i=0; i<count; i++) {
+    entry = entrylist[i];
     if (entry == NULL) break;
 
     // +2 for \0 and a possible slash
@@ -109,9 +110,10 @@ int os_GetFolderFiles(char *folder_path, char *hierarchy)
     }
 
     free(heap_path);
+    free(entry);
   }
+  free(entrylist);
 
-  free(dirstream);
   return error;
 }
 
@@ -169,7 +171,7 @@ void os_GetFileCreationModificationDate(char *path, struct prodos_file *file) {
 }
 
 
-char *my_strcpy(char *s1, int s1_size, char *s2) 
+char *my_strcpy(char *s1, int s1_size, char *s2)
 {
   return strcpy(s1, s2);
 }


### PR DESCRIPTION
This pull request includes several changes to support [reproducible builds](https://reproducible-builds.org/) in programs that use it during their build process, such as [Total Replay](https://github.com/a2-4am/4cade).

- Support [`SOURCE_DATE_EPOCH` environment variable](https://reproducible-builds.org/specs/source-date-epoch/) if present, using it in place of the current date and time
- Sort files alphabetically when building file lists, such as for the `ADDFOLDER` command
- Return a non-zero application error code if any part of the command failed, e.g. if even one file could not be added during an `ADDFOLDER` command